### PR TITLE
small fix: grid origin can be float too

### DIFF
--- a/pcb/pcb.go
+++ b/pcb/pcb.go
@@ -128,7 +128,7 @@ type EditorSetup struct {
 
 	UserVia                [2]float64
 	BlindBuriedViasAllowed bool
-	GridOrigin             [2]int
+	GridOrigin             [2]float64
 
 	ModEdgeWidth       float64
 	ModTextSize        []float64
@@ -514,7 +514,7 @@ func parseSetup(n sexp.Helper, ordering int) (*EditorSetup, error) {
 		case "blind_buried_vias_allowed":
 			e.BlindBuriedViasAllowed = c.Child(1).MustString() == "yes"
 		case "grid_origin":
-			e.GridOrigin = [2]int{c.Child(1).MustInt(), c.Child(2).MustInt()}
+			e.GridOrigin = [2]float64{c.Child(1).MustFloat64(), c.Child(2).MustFloat64()}
 
 		case "pcbplotparams":
 			e.PlotParams = map[string]PlotParam{}

--- a/pcb/writer.go
+++ b/pcb/writer.go
@@ -769,8 +769,8 @@ func (l *EditorSetup) write(sw *swriter.SExpWriter) error {
 	if l.GridOrigin[0] != 0 || l.GridOrigin[1] != 0 {
 		sw.StartList(true)
 		sw.StringScalar("grid_origin")
-		sw.IntScalar(l.GridOrigin[0])
-		sw.IntScalar(l.GridOrigin[1])
+		sw.StringScalar(f(l.GridOrigin[0]))
+		sw.StringScalar(f(l.GridOrigin[1]))
 		if err := sw.CloseList(false); err != nil {
 			return err
 		}


### PR DESCRIPTION
As can be seen in the attached file, the grid origin can be float too. So i added support for that in this PR

[grid_origin_float.zip](https://github.com/twitchyliquid64/kcgen/files/4742539/grid_origin_float.zip)
